### PR TITLE
updated DecodeSequence to test length of byte array before copying to…

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -222,7 +222,11 @@ func DecodeSequence(toparse []byte) ([]interface{}, error) {
 
 	lidx := 0
 	idx := 1 + seqLenLen
+	if 1+seqLenLen+seqLength > len(toparse) {
+		return nil, errors.New("sequence does not contain the amount of bytes reported in its length")
+	}
 	toparse = toparse[:(1 + seqLenLen + seqLength)]
+
 	// Let's guarantee progress.
 	for idx < len(toparse) && idx > lidx {
 		berType := toparse[idx]


### PR DESCRIPTION
… a slice to prevent an out of bounds error on malformed traps