### PR TITLE
NoPriv support + decode signed integers + Configure timeout + Improved error reporting

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -77,6 +77,9 @@ const (
 	AsnInform         BERType = 0xa6
 	AsnTrap2          BERType = 0xa7
 	AsnReport         BERType = 0xa8
+
+	noSuchObject   BERType = 0x80
+	noSuchInstance BERType = 0x81
 )
 
 // SNMPVersion indicates which SNMP version is in use.
@@ -170,6 +173,24 @@ func DecodeInteger(toparse []byte) (int, error) {
 	return val, nil
 }
 
+// DecodeIntegerSigned decodes a signed integer. Will error out if it's longer than 64 bits.
+func DecodeIntegerSigned(toparse []byte) (int, error) {
+	if len(toparse) > 8 {
+		return 0, fmt.Errorf("don't support more than 64 bits")
+	}
+	val := 0
+	for _, b := range toparse {
+		val = val*256 + int(b)
+	}
+	// If highest order bit is 1, number is negative: decode as 2's complement.
+	if toparse[0]&0x80 != 0 {
+		nbits := len(toparse) * 8
+		twotonbits := uint(1) << uint(nbits)
+		val = val - int(twotonbits)
+	}
+	return val, nil
+}
+
 // DecodeIPAddress decodes an IP address.
 func DecodeIPAddress(toparse []byte) (string, error) {
 	if len(toparse) != 4 {
@@ -244,7 +265,7 @@ func DecodeSequence(toparse []byte) ([]interface{}, error) {
 			}
 			result = append(result, berValue[0] == 0)
 		case AsnInteger:
-			decodedValue, err := DecodeInteger(berValue)
+			decodedValue, err := DecodeIntegerSigned(berValue)
 			if err != nil {
 				return nil, err
 			}
@@ -296,6 +317,10 @@ func DecodeSequence(toparse []byte) ([]interface{}, error) {
 				return nil, err
 			}
 			result = append(result, pdu)
+		case noSuchObject:
+			return nil, fmt.Errorf("No Such Object")
+		case noSuchInstance:
+			return nil, fmt.Errorf("No Such Instance currently exists at this OID")
 		default:
 			return nil, fmt.Errorf("did not understand type %v", berType)
 		}

--- a/snmp.go
+++ b/snmp.go
@@ -202,7 +202,7 @@ func (w SNMP) Get(oid Oid) (interface{}, error) {
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (w SNMP) GetMultiple(oids []Oid) (map[string]interface{}, error) {
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func (w *SNMP) Discover() error {
 	}
 
 	response := make([]byte, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return err
 	}
@@ -566,7 +566,7 @@ func (w SNMP) GetNext(oid Oid) (*Oid, interface{}, error) {
 	}
 
 	response := make([]byte, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -601,7 +601,7 @@ func (w SNMP) GetBulk(oid Oid, maxRepetitions int) (map[string]interface{}, erro
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/snmp.go
+++ b/snmp.go
@@ -500,7 +500,7 @@ func (w *SNMP) doGetV3(oid Oid, request BERType) (*Oid, interface{}, error) {
 	finalPacket := strings.Replace(string(packet), strings.Repeat("\x00", 12), authParam, 1)
 
 	response := make([]byte, bufSize)
-	numRead, err := poll(w.conn, []byte(finalPacket), response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, []byte(finalPacket), response, w.retries, w.timeout)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
We are using this cool module for a DNS Load Balancer used at CERN that gets feedback of the state of the nodes using SNMP with SNMPv3 user/password, we had to do a few updates that we include in this PR. They are the following

- Support for NoPriv option.

- Improved reporting of some error and border cases such as usmStatsUnknownEngineIDs.

- Decoding  signed integers as such (do not assume unsigned).

- Use the  timeout configured also for polling and retries.
